### PR TITLE
fix the MPI create group hang issue

### DIFF
--- a/tips/core/collective/utils.cc
+++ b/tips/core/collective/utils.cc
@@ -12,6 +12,7 @@ MPI_Op CollectiveOpKindToMpiOp(CollectiveOpKind op) {
     case CollectiveOpKind::MIN:
       return MPI_MIN;
   }
+  return MPI_OP_NULL;
 }
 
 }  // namespace collective

--- a/tips/core/common/rwlock.h
+++ b/tips/core/common/rwlock.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <pthread.h>
+
 #include "tips/core/common/common.h"
 
 namespace tips {

--- a/tips/core/common/thread_group.h
+++ b/tips/core/common/thread_group.h
@@ -1,10 +1,12 @@
 #pragma once
 
 #include <absl/synchronization/barrier.h>
+
 #include <functional>
 #include <memory>
 #include <thread>
 #include <vector>
+
 #include "tips/core/common/common.h"
 #include "tips/core/common/managed_thread.h"
 

--- a/tips/core/common/thread_group_test.cc
+++ b/tips/core/common/thread_group_test.cc
@@ -1,6 +1,6 @@
-#include <gtest/gtest.h>
-
 #include "tips/core/common/thread_group.h"
+
+#include <gtest/gtest.h>
 
 namespace tips {
 

--- a/tips/core/common/vec.h
+++ b/tips/core/common/vec.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cmath>
+
 #include "tips/core/common/common.h"
 
 namespace tips {

--- a/tips/core/mpi/mpi_group.h
+++ b/tips/core/mpi/mpi_group.h
@@ -1,11 +1,11 @@
 #pragma once
 
-#include "tips/core/common/common.h"
-#include "tips/core/mpi/tips_mpi.h"
-
 #include <absl/container/flat_hash_map.h>
 #include <absl/container/flat_hash_set.h>
 #include <absl/container/inlined_vector.h>
+
+#include "tips/core/common/common.h"
+#include "tips/core/mpi/tips_mpi.h"
 
 namespace tips {
 
@@ -58,15 +58,26 @@ class MpiGroup {
 
   int ToWorldRank() const { return ToWorldRank(this->mpi_rank()); }
 
+  ~MpiGroup() {
+    if (valid()) {
+      MPI_Comm_free(&mpi_comm_);
+    }
+
+    if (world_group_ != MPI_GROUP_NULL) MPI_Group_free(&world_group_);
+    if (my_group_ != MPI_GROUP_EMPTY) MPI_Group_free(&my_group_);
+  }
+
  private:
   bool initialized_{};
   absl::flat_hash_set<int> data_;
-  absl::flat_hash_map<int, int> rank_map_;
-  absl::InlinedVector<int, 6> rank_order_;
+  std::vector<int> rank_order_;
   MPI_Comm mpi_comm_{MPI_COMM_NULL};
 
-  int mpi_rank_{};
-  int mpi_size_{};
+  MPI_Group world_group_{MPI_GROUP_NULL};
+  MPI_Group my_group_{MPI_GROUP_NULL};
+
+  int mpi_rank_{-1};
+  int mpi_size_{-1};
 };
 
 }  // namespace tips

--- a/tips/core/mpi/mpi_group_test.cc
+++ b/tips/core/mpi/mpi_group_test.cc
@@ -1,18 +1,64 @@
 #include "tips/core/mpi/mpi_group.h"
+
 #include "tips/core/operations.h"
 
 namespace tips {
 
 void MpiGroup_basic() {
-  // CHECK_GE(mpi_size(), 4);
+  mpi_barrier();
+
+  CHECK_GE(mpi_size(), 4);
   MpiGroup group;
   group.AddRank(3);
-  group.AddRank(1);
+  group.AddRank(2);
   group.Initialize();
 
   if (group.valid()) {
-    CHECK_EQ(mpi_rank(), group.ToWorldRank());
+    // CHECK_EQ(mpi_rank(), group.ToWorldRank());
     LOG(INFO) << "my group rank: " << mpi_rank() << " -> " << group.mpi_rank();
+  }
+
+  mpi_barrier();
+
+  MPI_LOG << "after barrirer";
+}
+
+void MpiGroup_basic1() {
+  // Get the rank and size in the original communicator
+  int world_rank, world_size;
+  MPI_Comm_rank(MPI_COMM_WORLD, &world_rank);
+  MPI_Comm_size(MPI_COMM_WORLD, &world_size);
+
+  // Get the group of processes in MPI_COMM_WORLD
+  MPI_Group world_group;
+  MPI_Comm_group(MPI_COMM_WORLD, &world_group);
+
+  int n              = 2;
+  const int ranks[2] = {1, 3};
+
+  // Construct a group containing all of the prime ranks in world_group
+  MPI_Group prime_group;
+  MPI_Group_incl(world_group, 2, ranks, &prime_group);
+
+  // Create a new communicator based on the group
+  MPI_Comm prime_comm;
+  MPI_Comm_create_group(MPI_COMM_WORLD, prime_group, 0, &prime_comm);
+
+  int prime_rank = -1, prime_size = -1;
+  // If this rank isn't in the new communicator, it will be
+  // MPI_COMM_NULL. Using MPI_COMM_NULL for MPI_Comm_rank or
+  // MPI_Comm_size is erroneous
+  if (MPI_COMM_NULL != prime_comm) {
+    MPI_Comm_rank(prime_comm, &prime_rank);
+    MPI_Comm_size(prime_comm, &prime_size);
+  }
+
+  printf("WORLD RANK/SIZE: %d/%d \t PRIME RANK/SIZE: %d/%d\n", world_rank, world_size, prime_rank, prime_size);
+
+  if (prime_comm != MPI_COMM_NULL) {
+    MPI_Group_free(&world_group);
+    MPI_Group_free(&prime_group);
+    MPI_Comm_free(&prime_comm);
   }
 }
 
@@ -22,6 +68,8 @@ int main() {
   tips::tips_init();
 
   tips::MpiGroup_basic();
+
+  CHECK_EQ(tips::mpi_size(), 4);
 
   tips::tips_shutdown();
 }

--- a/tips/core/mpi/tips_mpi.h
+++ b/tips/core/mpi/tips_mpi.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <mpi.h>
 #include <stdint.h>
+#include <unistd.h>
 
 #include "tips/core/common/logging.h"
 #include "tips/core/common/naive_buffer.h"
@@ -114,7 +115,7 @@ void mpi_broadcast(T* p, int count, int root) {
   }
 }
 
-inline void mpi_barrier() { MPI_Barrier(mpi_comm()); }
+// inline void mpi_barrier() { MPI_Barrier(mpi_comm()); }
 
 inline int mpi_size() {
   int size;
@@ -124,7 +125,9 @@ inline int mpi_size() {
 
 std::string mpi_rank_repr();
 
+void mpi_barrier(MPI_Comm comm = mpi_comm());
+
 }  // namespace tips
 
-#define MPI_LOG VLOG(2) << ::tips::mpi_rank_repr() << " "
-#define MPI_WARN VLOG(3) << ::tips::mpi_rank_repr() << " "
+#define MPI_LOG LOG(INFO) << ::tips::mpi_rank_repr() << " "
+#define MPI_WARN LOG(INFO) << ::tips::mpi_rank_repr() << " "

--- a/tips/core/ps/access_method_test.cc
+++ b/tips/core/ps/access_method_test.cc
@@ -1,5 +1,7 @@
 #include "tips/core/ps/access_method.h"
+
 #include <gtest/gtest.h>
+
 #include "tips/core/operations.h"
 #include "tips/core/ps/sparse_access_method.h"
 

--- a/tips/core/ps/dense_table.h
+++ b/tips/core/ps/dense_table.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <absl/types/span.h>
+
 #include "tips/core/common/common.h"
 #include "tips/core/ps/table.h"
 

--- a/tips/core/ps/dense_table_test.cc
+++ b/tips/core/ps/dense_table_test.cc
@@ -1,7 +1,8 @@
+#include "tips/core/ps/dense_table.h"
+
 #include <gtest/gtest.h>
 
 #include "tips/core/operations.h"
-#include "tips/core/ps/dense_table.h"
 
 namespace tips {
 namespace ps {

--- a/tips/core/ps/server_worker_route.h
+++ b/tips/core/ps/server_worker_route.h
@@ -3,6 +3,7 @@
 #include <absl/container/flat_hash_set.h>
 #include <absl/container/inlined_vector.h>
 #include <mpi.h>
+
 #include <unordered_set>
 #include <vector>
 

--- a/tips/core/ps/sparse_table.h
+++ b/tips/core/ps/sparse_table.h
@@ -3,6 +3,7 @@
 #include <absl/container/flat_hash_map.h>
 #include <absl/container/inlined_vector.h>
 #include <absl/hash/hash.h>
+
 #include <fstream>
 #include <iostream>
 #include <limits>

--- a/tips/core/ps/sparse_table_test.cc
+++ b/tips/core/ps/sparse_table_test.cc
@@ -1,4 +1,5 @@
 #include <gtest/gtest.h>
+
 #include "tips/core/operations.h"
 #include "tips/core/ps/access_method.h"
 

--- a/tips/core/ps/table.h
+++ b/tips/core/ps/table.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <gflags/gflags.h>
+
 #include "tips/core/common/channel.h"
 #include "tips/core/common/common.h"
 #include "tips/core/common/thread_group.h"


### PR DESCRIPTION
The hang issue is due to the order of the ranks feed to `MPI_Comm_create_group`.